### PR TITLE
Change BMfont extension to fnt

### DIFF
--- a/StardewXnbHack/Framework/Writers/XmlSourceWriter.cs
+++ b/StardewXnbHack/Framework/Writers/XmlSourceWriter.cs
@@ -27,7 +27,7 @@ namespace StardewXnbHack.Framework.Writers
         public override bool TryWriteFile(object asset, string toPathWithoutExtension, string relativePath, Platform platform, out string error)
         {
             XmlSource value = (XmlSource)asset;
-            File.WriteAllText($"{toPathWithoutExtension}.xml", value.Source);
+            File.WriteAllText($"{toPathWithoutExtension}.fnt", value.Source);
 
             error = null;
             return true;


### PR DESCRIPTION
Changed the extension for the BMFont files from xml to fnt, as that's what BMFont (https://www.angelcode.com/products/bmfont/) actually uses.