### PR TITLE
App config for simplified distribution

### DIFF
--- a/StardewXnbHack/App.config
+++ b/StardewXnbHack/App.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <probing privatePath="smapi-internal"/>
+        </assemblyBinding>
+    </runtime>
+</configuration>


### PR DESCRIPTION
Adds an app config so that dependencies are probed from the 'smapi-internal' folder, allowing for distribution without dependencies.