### PR TITLE
Added a local version of the extension method Platform.IsMono.

### DIFF
--- a/StardewXnbHack/Framework/PlatformExtensions.cs
+++ b/StardewXnbHack/Framework/PlatformExtensions.cs
@@ -8,8 +8,7 @@ namespace StardewXnbHack.Framework
         /// <param name="platform">The current platform.</param>
         public static bool IsMono(this Platform platform)
         {
-            string platformAsString = platform.ToString();
-            return platformAsString == nameof(Platform.Linux) || platformAsString == nameof(Platform.Mac);
+            return platform == Platform.Linux || platform == Platform.Mac;
         }
     }
 }

--- a/StardewXnbHack/Framework/PlatformExtensions.cs
+++ b/StardewXnbHack/Framework/PlatformExtensions.cs
@@ -1,0 +1,15 @@
+using StardewModdingAPI.Toolkit.Utilities;
+
+namespace StardewXnbHack.Framework
+{
+    internal static class PlatformExtensions
+    {
+        /// <summary>Get whether the platform uses Mono.</summary>
+        /// <param name="platform">The current platform.</param>
+        public static bool IsMono(this Platform platform)
+        {
+            string platformAsString = platform.ToString();
+            return platformAsString == nameof(Platform.Linux) || platformAsString == nameof(Platform.Mac);
+        }
+    }
+}

--- a/StardewXnbHack/Framework/PlatformExtensions.cs
+++ b/StardewXnbHack/Framework/PlatformExtensions.cs
@@ -2,6 +2,7 @@ using StardewModdingAPI.Toolkit.Utilities;
 
 namespace StardewXnbHack.Framework
 {
+    /// <summary>Provides extension methods for the <see cref="Platform" /> enum.</summary>
     internal static class PlatformExtensions
     {
         /// <summary>Get whether the platform uses Mono.</summary>


### PR DESCRIPTION
The method was recently (3.9.5) removed from SMAPI. This should fix #10.